### PR TITLE
Soften homepage and practice palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>English Tenses Trainer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <h1>English Tenses Trainer</h1>
+    <p>Select a tense to begin exploring lessons and practice activities.</p>
+  </header>
+  <main class="tenses-grid" aria-label="List of English tenses">
+    <article class="tense-card" tabindex="0">
+      <h2>Present Simple</h2>
+    </article>
+    <a class="tense-card" href="present-continuous.html">
+      <h2>Present Continuous</h2>
+    </a>
+    <article class="tense-card" tabindex="0">
+      <h2>Present Perfect</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Present Perfect Continuous</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Past Simple</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Past Continuous</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Past Perfect</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Past Perfect Continuous</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Future Simple</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Future Continuous</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Future Perfect</h2>
+    </article>
+    <article class="tense-card" tabindex="0">
+      <h2>Future Perfect Continuous</h2>
+    </article>
+  </main>
+  <footer class="footer">
+    <p>More interactive lessons and practice features are coming soon.</p>
+  </footer>
+</body>
+</html>

--- a/present-continuous.html
+++ b/present-continuous.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Present Continuous Practice</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="practice-page">
+  <header class="practice-header">
+    <a class="back-link" href="index.html">Return to the list of tenses</a>
+    <h1>Present Continuous Practice</h1>
+    <p>Arrange the words to build the English sentence. Use the translation as your hint.</p>
+  </header>
+  <main class="exercise-list" data-exercise-list></main>
+  <template id="exercise-template">
+    <article class="exercise-card">
+      <header class="exercise-header">
+        <span class="exercise-number"></span>
+        <p class="exercise-translation"></p>
+      </header>
+      <ul class="word-list" role="list"></ul>
+      <div class="exercise-controls">
+        <button type="button" class="reset-button">Reset</button>
+        <button type="button" class="correct-button" hidden>correct</button>
+      </div>
+    </article>
+  </template>
+  <script>
+    const exercises = [
+      { english: "I’m working.", translation: "Я работаю." },
+      { english: "I’m not watching TV.", translation: "Я не смотрю телевизор." },
+      { english: "Maria is reading a newspaper.", translation: "Мария читает газету." },
+      { english: "She isn’t eating.", translation: "Она не ест." },
+      { english: "She’s not eating.", translation: "Она не ест." },
+      { english: "The bus is coming.", translation: "Автобус подъезжает." },
+      { english: "We’re having dinner.", translation: "Мы ужинаем." },
+      { english: "You’re not listening to me.", translation: "Ты меня не слушаешь." },
+      { english: "You aren’t listening to me.", translation: "Ты меня не слушаешь." },
+      { english: "The children are doing their homework.", translation: "Дети делают домашнюю работу." },
+      { english: "Please be quiet.", translation: "Пожалуйста, будьте тише." },
+      { english: "I’m working now.", translation: "Я сейчас работаю." },
+      { english: "Look, there’s Sarah.", translation: "Смотри, вон Сара." },
+      { english: "She’s wearing a brown coat.", translation: "На ней коричневое пальто." },
+      { english: "The weather is nice.", translation: "Погода хорошая." },
+      { english: "It’s not raining.", translation: "Дождя нет." },
+      { english: "Where are the children?", translation: "Где дети?" },
+      { english: "They’re playing in the park.", translation: "Они играют в парке." },
+      { english: "We’re having dinner now.", translation: "Мы сейчас ужинаем." },
+      { english: "Can I call you later?", translation: "Можно я перезвоню позже?" },
+      { english: "You can turn off the television.", translation: "Ты можешь выключить телевизор." },
+      { english: "I’m not watching it.", translation: "Я его не смотрю." },
+      { english: "She’s eating an apple.", translation: "Она ест яблоко." },
+      { english: "He is waiting for a bus.", translation: "Он ждёт автобус." },
+      { english: "They are playing football.", translation: "Они играют в футбол." },
+      { english: "He is lying on the floor.", translation: "Он лежит на полу." },
+      { english: "They are having breakfast.", translation: "Они завтракают." },
+      { english: "She is sitting on the table.", translation: "Она сидит на столе." },
+      { english: "He’s cooking.", translation: "Он готовит." },
+      { english: "You are standing on my foot.", translation: "Ты наступил мне на ногу." },
+      { english: "Oh, I’m sorry!", translation: "Ой, прости!" },
+      { english: "Look! Somebody is swimming in the river.", translation: "Смотри! Кто-то плывёт в реке." },
+      { english: "We’re here on holiday.", translation: "Мы здесь в отпуске." },
+      { english: "We’re staying at the Central Hotel.", translation: "Мы остановились в гостинице «Сентрал»." },
+      { english: "Where’s Sue?", translation: "Где Сью?" },
+      { english: "She’s having a shower.", translation: "Она принимает душ." },
+      { english: "They’re building a new hotel in the city centre at the moment.", translation: "Сейчас они строят новый отель в центре города." },
+      { english: "I’m going now.", translation: "Я ухожу." },
+      { english: "Goodbye.", translation: "До свидания." },
+      { english: "Jane isn’t having dinner.", translation: "Джейн не ужинает." },
+      { english: "Jane’s watching TV.", translation: "Джейн смотрит телевизор." },
+      { english: "She isn’t sitting on the floor.", translation: "Она не сидит на полу." },
+      { english: "She isn’t reading a book.", translation: "Она не читает книгу." },
+      { english: "She isn’t playing the piano.", translation: "Она не играет на пианино." },
+      { english: "She’s laughing.", translation: "Она смеётся." },
+      { english: "She’s wearing a hat.", translation: "На ней шляпа." },
+      { english: "She isn’t drinking coffee.", translation: "Она не пьёт кофе." },
+      { english: "Kate wants to work in Italy, so she’s learning Italian.", translation: "Кейт хочет работать в Италии, поэтому она учит итальянский." },
+      { english: "Some friends of mine are building their own house.", translation: "Некоторые мои друзья строят свой дом." },
+      { english: "They hope to finish it next summer.", translation: "Они надеются закончить его следующим летом." },
+      { english: "You’re working hard today.", translation: "Ты сегодня усердно работаешь." },
+      { english: "Yes, I have a lot to do.", translation: "Да, у меня много дел." },
+      { english: "The company I work for isn’t doing so well this year.", translation: "Компания, в которой я работаю, в этом году дела ведёт не очень хорошо." },
+      { english: "Is your English getting better?", translation: "Твой английский улучшается?" },
+      { english: "The population of the world is increasing very fast.", translation: "Население мира очень быстро растёт." },
+      { english: "At first I didn’t like my job, but I’m beginning to enjoy it now.", translation: "Сначала мне не нравилась моя работа, но сейчас она начинает мне нравиться." },
+      { english: "Please don’t make so much noise.", translation: "Пожалуйста, не шумите так сильно." },
+      { english: "It’s getting late.", translation: "Становится поздно." },
+      { english: "I need to eat something soon.", translation: "Мне скоро нужно что-нибудь поесть." },
+      { english: "I’m getting hungry.", translation: "Я начинаю голодать." },
+      { english: "I don’t have anywhere to live right now.", translation: "Мне сейчас негде жить." },
+      { english: "I’m looking for an apartment.", translation: "Я ищу квартиру." },
+      { english: "We need to leave soon.", translation: "Нам нужно скоро уходить." },
+      { english: "It’s starting to rain.", translation: "Начинается дождь." },
+      { english: "They don’t need their car any more.", translation: "Им больше не нужна их машина." },
+      { english: "They’re trying to sell it.", translation: "Они пытаются её продать." },
+      { english: "Things are not so good at work.", translation: "На работе дела идут не очень хорошо." },
+      { english: "The company is losing money.", translation: "Компания теряет деньги." },
+      { english: "It isn’t true what they said.", translation: "То, что они сказали, неправда." },
+      { english: "They’re lying.", translation: "Они лгут." },
+      { english: "We’re going to get wet.", translation: "Мы промокнем." },
+      { english: "It’s starting to rain.", translation: "Начинается дождь." },
+      { english: "I’m trying to work.", translation: "Я пытаюсь работать." },
+      { english: "Let’s go out now.", translation: "Давай выйдем сейчас." },
+      { english: "It isn’t raining any more.", translation: "Дождь больше не идёт." },
+      { english: "You can turn off the radio.", translation: "Ты можешь выключить радио." },
+      { english: "I’m not listening to it.", translation: "Я его не слушаю." },
+      { english: "Kate phoned me last night.", translation: "Кейт позвонила мне прошлой ночью." },
+      { english: "She’s on holiday in France.", translation: "Она в отпуске во Франции." },
+      { english: "She’s having a great time and doesn’t want to come back.", translation: "Она прекрасно проводит время и не хочет возвращаться." },
+      { english: "I want to lose weight, so this week I’m not eating lunch.", translation: "Я хочу похудеть, поэтому на этой неделе я не обедаю." },
+      { english: "Andrew has just started evening classes.", translation: "Эндрю только что начал вечерние занятия." },
+      { english: "He’s learning Japanese.", translation: "Он изучает японский." },
+      { english: "Paul and Sally have had an argument.", translation: "Пол и Салли поссорились." },
+      { english: "They aren’t speaking to each other.", translation: "Они не разговаривают друг с другом." },
+      { english: "I’m getting tired.", translation: "Я устаю." },
+      { english: "I need a rest.", translation: "Мне нужен отдых." },
+      { english: "Tim isn’t working today.", translation: "Тим сегодня не работает." },
+      { english: "He’s taken the day off.", translation: "Он взял выходной." },
+      { english: "I’m looking for Sophie.", translation: "Я ищу Софи." },
+      { english: "Do you know where she is?", translation: "Ты знаешь, где она?" },
+      { english: "The world is changing.", translation: "Мир меняется." },
+      { english: "Things never stay the same.", translation: "Ничто не остаётся прежним." },
+      { english: "The situation is already bad and it is getting worse.", translation: "Ситуация уже плохая, и она становится ещё хуже." },
+      { english: "The cost of living is rising.", translation: "Стоимость жизни растёт." },
+      { english: "Every year things are more expensive.", translation: "Каждый год всё становится дороже." },
+      { english: "The weather is starting to improve.", translation: "Погода начинает улучшаться." },
+      { english: "The rain has stopped, and the wind isn’t as strong.", translation: "Дождь прекратился, и ветер уже не такой сильный." }
+    ];
+
+    const template = document.getElementById('exercise-template');
+    const container = document.querySelector('[data-exercise-list]');
+
+    const supportsSpeech = 'speechSynthesis' in window;
+
+    function shuffle(array) {
+      const result = [...array];
+      for (let i = result.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [result[i], result[j]] = [result[j], result[i]];
+      }
+      return result;
+    }
+
+    function speakSentence(sentence) {
+      if (!supportsSpeech) return;
+      const utterance = new SpeechSynthesisUtterance(sentence.replace(/’/g, "'"));
+      utterance.lang = 'en-US';
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    }
+
+    exercises.forEach((exercise, index) => {
+      const clone = template.content.firstElementChild.cloneNode(true);
+      const numberEl = clone.querySelector('.exercise-number');
+      const translationEl = clone.querySelector('.exercise-translation');
+      const wordList = clone.querySelector('.word-list');
+      const resetButton = clone.querySelector('.reset-button');
+      const correctButton = clone.querySelector('.correct-button');
+
+      numberEl.textContent = `${index + 1}.`;
+      translationEl.textContent = exercise.translation;
+
+      const words = exercise.english.trim().split(/\s+/);
+      const originalOrder = [...words];
+      const shuffledOrder = shuffle(words);
+
+      let hasSpoken = false;
+      let draggedItem = null;
+
+      function renderWords(order) {
+        wordList.innerHTML = '';
+        order.forEach((word) => {
+          const item = document.createElement('li');
+          item.className = 'word-item';
+          item.textContent = word;
+          item.draggable = true;
+          item.dataset.word = word;
+          wordList.appendChild(item);
+        });
+        draggedItem = null;
+      }
+
+      renderWords(shuffledOrder);
+
+      wordList.addEventListener('dragstart', (event) => {
+        const target = event.target.closest('.word-item');
+        if (!target) return;
+        draggedItem = target;
+        target.classList.add('word-item--dragging');
+      });
+
+      wordList.addEventListener('dragend', (event) => {
+        const target = event.target.closest('.word-item');
+        if (target) {
+          target.classList.remove('word-item--dragging');
+        }
+        draggedItem = null;
+        checkOrder();
+      });
+
+      wordList.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        const target = event.target.closest('.word-item');
+        if (!draggedItem) return;
+
+        if (!target) {
+          wordList.appendChild(draggedItem);
+          return;
+        }
+
+        if (draggedItem === target) return;
+
+        const items = Array.from(wordList.children);
+        const draggedIndex = items.indexOf(draggedItem);
+        const targetIndex = items.indexOf(target);
+
+        if (draggedIndex < targetIndex) {
+          wordList.insertBefore(draggedItem, target.nextSibling);
+        } else {
+          wordList.insertBefore(draggedItem, target);
+        }
+      });
+
+      wordList.addEventListener('drop', (event) => {
+        event.preventDefault();
+        checkOrder();
+      });
+
+      resetButton.addEventListener('click', () => {
+        renderWords(shuffledOrder);
+        hasSpoken = false;
+        correctButton.hidden = true;
+        clone.classList.remove('exercise-card--complete');
+      });
+
+      correctButton.addEventListener('click', () => {
+        correctButton.blur();
+      });
+
+      function checkOrder() {
+        const current = Array.from(wordList.children).map((item) => item.dataset.word);
+        const isCorrect = current.length === originalOrder.length && current.every((word, i) => word === originalOrder[i]);
+        if (isCorrect) {
+          clone.classList.add('exercise-card--complete');
+          correctButton.hidden = false;
+          if (!hasSpoken) {
+            speakSentence(exercise.english);
+            hasSpoken = true;
+          }
+        } else {
+          clone.classList.remove('exercise-card--complete');
+          correctButton.hidden = true;
+          hasSpoken = false;
+        }
+      }
+
+      container.appendChild(clone);
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,272 @@
+:root {
+  color-scheme: dark;
+  --background: #1a2f4f;
+  --card-bg: rgba(38, 76, 124, 0.52);
+  --card-border: rgba(207, 228, 255, 0.6);
+  --card-hover: rgba(106, 154, 201, 0.92);
+  --text-primary: #f5f7ff;
+  --text-secondary: #d3dcff;
+  --accent: #8dd4ff;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, #274b7a, var(--background));
+  color: var(--text-primary);
+}
+
+.hero {
+  text-align: center;
+  padding: 3rem 1.5rem 1rem;
+}
+
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  letter-spacing: 0.08em;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 2vw, 1.25rem);
+}
+
+.tenses-grid {
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 5vw, 6rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  width: min(1100px, 100%);
+  margin: 0 auto;
+}
+
+.tense-card {
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--card-border);
+  border-radius: 18px;
+  padding: 1.75rem 1rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+
+.tense-card:focus,
+.tense-card:hover {
+  outline: none;
+  transform: translateY(-6px);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  border-color: var(--accent);
+  background: var(--card-hover);
+}
+
+.tense-card h2 {
+  margin: 0;
+  text-align: center;
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
+  font-weight: 600;
+}
+
+.footer {
+  text-align: center;
+  padding: 1.5rem 1rem 2.5rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.practice-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, #274b7a, var(--background));
+  color: var(--text-primary);
+}
+
+.practice-header {
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 6vw, 4rem) 1.5rem;
+  text-align: center;
+}
+
+.practice-header h1 {
+  margin: 0.75rem 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.06em;
+}
+
+.practice-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 2.4vw, 1.3rem);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.back-link::before {
+  content: '←';
+  font-size: 1.1em;
+}
+
+.back-link:focus-visible,
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.exercise-list {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 0 clamp(1rem, 5vw, 4rem) clamp(2rem, 6vw, 4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.exercise-card {
+  border: 2px solid var(--card-border);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  background: rgba(38, 76, 124, 0.4);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.exercise-card--complete {
+  border-color: var(--accent);
+  box-shadow: 0 24px 45px rgba(0, 0, 0, 0.45);
+}
+
+.exercise-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.exercise-number {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.exercise-translation {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.word-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  min-height: 3rem;
+}
+
+.word-item {
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(141, 212, 255, 0.18);
+  border: 1px solid rgba(141, 212, 255, 0.45);
+  color: var(--text-primary);
+  cursor: grab;
+  user-select: none;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.word-item:focus,
+.word-item:hover {
+  outline: none;
+  background: rgba(141, 212, 255, 0.32);
+  border-color: var(--accent);
+}
+
+.word-item--dragging {
+  opacity: 0.6;
+  transform: scale(1.05);
+  cursor: grabbing;
+}
+
+.exercise-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.reset-button,
+.correct-button {
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.reset-button {
+  background: transparent;
+  color: var(--text-primary);
+  border-color: rgba(141, 212, 255, 0.4);
+}
+
+.reset-button:focus-visible,
+.reset-button:hover {
+  background: rgba(141, 212, 255, 0.22);
+}
+
+.correct-button {
+  background: var(--accent);
+  color: #041024;
+  box-shadow: 0 10px 18px rgba(141, 212, 255, 0.38);
+}
+
+.correct-button:focus-visible,
+.correct-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 24px rgba(141, 212, 255, 0.5);
+}
+
+@media (max-width: 640px) {
+  .exercise-translation {
+    font-size: 1rem;
+  }
+
+  .word-item {
+    font-size: 0.95rem;
+  }
+}


### PR DESCRIPTION
## Summary
- brighten the shared color variables so the homepage and Present Continuous trainer use a lighter bluish background
- update exercise card and chip styling to match the lighter treatment on the practice page
- adjust button borders and shadows to stay consistent with the softened accent color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7061d79408326ab401f96c1b880f4